### PR TITLE
patch-2

### DIFF
--- a/scripts/setenv-docker-customize.sh
+++ b/scripts/setenv-docker-customize.sh
@@ -144,7 +144,7 @@ else
       replace_in_file /opt/exo/conf/server.xml "jdbc:mysql://localhost:3306/plf" "jdbc:mysql://${EXO_DB_HOST}:${EXO_DB_PORT}/${EXO_DB_NAME}"
       replace_in_file /opt/exo/conf/server.xml 'username="plf" password="plf"' 'username="'${EXO_DB_USER}'" password="'${EXO_DB_PASSWORD}'"'
       if [ "${EXO_DB_INSTALL_DRIVER}" = "true" ]; then
-        ${EXO_APP_DIR}/addon install ${_ADDON_MGR_OPTIONS:-} exo-jdbc-driver-mysql --batch-mode
+        ${EXO_APP_DIR}/addon install ${_ADDON_MGR_OPTIONS:-} exo-jdbc-driver-mysql --no-compat --batch-mode
         if [ $? != 0 ]; then
           echo "[ERROR] Impossible to install MySQL Driver add-on."
           exit 1


### PR DESCRIPTION
Need to force the No Compatibility flag on the addons install, as we've apparently fallen out of the supported version for this mysql addon.
Errors reported on dev/qa:

[ERROR] Impossible to install MySQL Driver add-on.
[ERROR] The add-on exo-jdbc-driver-mysql:1.1.0 is not compatible : Only eXo platform versions [5-m1,) are supported. Use --no-compat to bypass this compatibility check and install anyway